### PR TITLE
Correct bounds checking in Matrix.set

### DIFF
--- a/Test.elm
+++ b/Test.elm
@@ -154,9 +154,12 @@ set = suite "Set"
     test "Set left middle 5x3" 
       <| assertEqual (Just 5) 
       <| Matrix.get 3 1 <| Matrix.set 3 1 5 <| Matrix.repeat 5 3 1,
-    test "Set outside of range does nothing"
+    test "Set outside of range does not change size"
       <| (\x -> assertEqual (1, 1) x.size)
-      <| Matrix.set 5 5 1 <| Matrix.repeat 1 1 1
+      <| Matrix.set 5 5 1 <| Matrix.repeat 1 1 1,
+    test "Set with negative index does nothing"
+      <| assertEqual (Matrix.repeat 3 3 1)
+      <| Matrix.set (-1) 2 0 <| Matrix.repeat 3 3 1
   ]
 
 update : Test

--- a/src/Matrix.elm
+++ b/src/Matrix.elm
@@ -164,7 +164,7 @@ set i j v matrix =
   let
     pos = (j * fst matrix.size) + i
   in
-    if i < width matrix && j < height matrix then 
+    if (i < width matrix && i > -1) && (j < height matrix && j > -1) then 
       { matrix | data = Array.set pos v matrix.data }
     else 
       matrix


### PR DESCRIPTION
The documentation of `Matrix.set` claims that if the access is out of bounds, the unmodified matrix is returned. But that's not currently what is happening. For example, `Matrix.get 2 1 (Matrix.set (-1) 2 True (Matrix.repeat 3 3 False))` erroneously evaluates to `Just True`. With this pull request, the proper behavior should be enforced.
